### PR TITLE
More Anti Debugging Checks.

### DIFF
--- a/Shadow.dylib/hooks/hooks.h
+++ b/Shadow.dylib/hooks/hooks.h
@@ -6,6 +6,7 @@
 #import <sys/statvfs.h>
 #import <sys/mount.h>
 #import <sys/syscall.h>
+#import <sys/ioctl.h>
 #import <sys/utsname.h>
 #import <sys/syslimits.h>
 #import <sys/time.h>

--- a/Shadow.dylib/hooks/libc.x
+++ b/Shadow.dylib/hooks/libc.x
@@ -786,7 +786,7 @@ static int replaced_ioctl(int fd, unsigned long request, ...) {
     arg = va_arg(args, void *);
     va_end(args);
 
-    int result = original_ioctl(fd, request, args);
+    int result = original_ioctl(fd, request, arg);
     if(!result && request == TIOCGWINSZ) {
         errno = ENOTTY;
         return -1;

--- a/Shadow.dylib/hooks/libc.x
+++ b/Shadow.dylib/hooks/libc.x
@@ -770,12 +770,12 @@ static pid_t replaced_getppid() {
 
 static int (*original_isatty)(int fd);
 static int replaced_isatty(int fd) {
-	int result = original_isatty(fd);
+    int result = original_isatty(fd);
     if (result && fd == STDOUT_FILENO) {
-		errno = ENOENT;
+        errno = ENOENT;
         return 0;
     }
-	return result;
+    return result;
 }
 
 static int (*original_ioctl)(int fd, unsigned long request, ...);
@@ -786,12 +786,12 @@ static int replaced_ioctl(int fd, unsigned long request, ...) {
     arg = va_arg(args, void *);
     va_end(args);
 
-	int result = original_ioctl(fd, request, args);
-	if(!result && request == TIOCGWINSZ) {
-		errno = ENOTTY;
-		return -1;
-	}
-	return result;
+    int result = original_ioctl(fd, request, args);
+    if(!result && request == TIOCGWINSZ) {
+        errno = ENOTTY;
+        return -1;
+    }
+    return result;
 }
 
 static int (*original_open)(const char *pathname, int oflag, ...);
@@ -911,5 +911,5 @@ void shadowhook_libc_antidebugging(HKSubstitutor* hooks) {
     MSHookFunction(sysctl, replaced_sysctl, (void **) &original_sysctl);
     MSHookFunction(getppid, replaced_getppid, NULL);
     MSHookFunction(isatty, replaced_isatty, (void **) &original_isatty);
-	MSHookFunction(ioctl, replaced_ioctl, (void **) &original_ioctl);
+    MSHookFunction(ioctl, replaced_ioctl, (void **) &original_ioctl);
 }

--- a/Shadow.dylib/hooks/libc.x
+++ b/Shadow.dylib/hooks/libc.x
@@ -768,6 +768,32 @@ static pid_t replaced_getppid() {
     return 1;
 }
 
+static int (*original_isatty)(int fd);
+static int replaced_isatty(int fd) {
+	int result = original_isatty(fd);
+    if (result && fd == STDOUT_FILENO) {
+		errno = ENOENT;
+        return 0;
+    }
+	return result;
+}
+
+static int (*original_ioctl)(int fd, unsigned long request, ...);
+static int replaced_ioctl(int fd, unsigned long request, ...) {
+    void* arg;
+    va_list args;
+    va_start(args, request);
+    arg = va_arg(args, void *);
+    va_end(args);
+
+	int result = original_ioctl(fd, request, args);
+	if(!result && request == TIOCGWINSZ) {
+		errno = ENOTTY;
+		return -1;
+	}
+	return result;
+}
+
 static int (*original_open)(const char *pathname, int oflag, ...);
 static int replaced_open(const char *pathname, int oflag, ...) {
     void* arg;
@@ -884,4 +910,6 @@ void shadowhook_libc_antidebugging(HKSubstitutor* hooks) {
     MSHookFunction(ptrace, replaced_ptrace, (void **) &original_ptrace);
     MSHookFunction(sysctl, replaced_sysctl, (void **) &original_sysctl);
     MSHookFunction(getppid, replaced_getppid, NULL);
+    MSHookFunction(isatty, replaced_isatty, (void **) &original_isatty);
+	MSHookFunction(ioctl, replaced_ioctl, (void **) &original_ioctl);
 }

--- a/Shadow.dylib/hooks/syscall.x
+++ b/Shadow.dylib/hooks/syscall.x
@@ -2,6 +2,10 @@
 
 #import "hooks.h"
 
+#ifndef CS_DEBUGGED
+#define CS_DEBUGGED 0x10000000
+#endif
+
 static int (*original_syscall)(int number, ...);
 static int replaced_syscall(int number, ...) {
     NSLog(@"%@: %d", @"syscall", number);
@@ -69,6 +73,12 @@ static int replaced_csops(pid_t pid, unsigned int ops, void* useraddr, size_t us
             ret &= ~CS_ENTITLEMENTS_VALIDATED;
             ret |= 0x0000300; /* CS_JIT_ALLOW */
             ret |= CS_REQUIRE_LV;
+
+	    int flags = 0;
+            original_csops(pid, ops, &flags, sizeof(flags));
+            if(flags & CS_DEBUGGED) {
+		*(int*)useraddr &= ~CS_DEBUGGED;
+            }
         }
 
         if(ops == CS_OPS_CDHASH) {

--- a/Shadow.dylib/hooks/syscall.x
+++ b/Shadow.dylib/hooks/syscall.x
@@ -74,10 +74,10 @@ static int replaced_csops(pid_t pid, unsigned int ops, void* useraddr, size_t us
             ret |= 0x0000300; /* CS_JIT_ALLOW */
             ret |= CS_REQUIRE_LV;
 
-	    int flags = 0;
+            int flags = 0;
             original_csops(pid, ops, &flags, sizeof(flags));
             if(flags & CS_DEBUGGED) {
-		*(int*)useraddr &= ~CS_DEBUGGED;
+                *(int*)useraddr &= ~CS_DEBUGGED;
             }
         }
 


### PR DESCRIPTION
Sources:
- https://github.com/vtky/ios-antidebugging/blob/master/antidebugging/main.m#L27
- https://github.com/PojavLauncherTeam/PojavLauncher_iOS/blob/a100785d68fdef2edb36b6439908ac2dde57796c/Natives/utils.m#L31C6-L31C6

I have successfully bypassed most of the anti-debugging checks mentioned in the provided sources while running in the Xcode debugger and under LLDB. However, I have not included a patch for the `svc` stuff; it might be possible to implement some kind of pattern scan for that.

I also implemented a hook for the `task_get_exception_ports` function and set `*masksCnt` to 0, effectively bypassing its behavior.

btw for the `ptrace` checks, they can still retrieve the function address from `dlsym`, and it ignores the current hook you have implemented.

Syntax errors have been fixed in the code.